### PR TITLE
Add Tymoji to a dropdown menu

### DIFF
--- a/tymoji.user.js
+++ b/tymoji.user.js
@@ -140,6 +140,24 @@ addEmojis = function(additional) {
     errorImage.isMap = "false";
  errorImage.parentElement.insertBefore(document.createTextNode(errorImage.title), errorImage);
 }
+var k = mySettings.markupSet.push({name:'Tymoji', openWith:'', closeWith:'', dropMenu:[]}) - 1;
+for(var j = 0, n = emojisData.length; j < n; j++){
+mySettings.markupSet[k].dropMenu.push({'name': emojisData[j][2], 'openWith':emojisData[j][2]});
+}
+document.getElementsByClassName("markItUpHeader")[0].innerHTML = "";
+            $(".markup").markItUp(mySettings);
+            document.getElementsByClassName("markItUpButton")[177].style.backgroundImage = "url('" + emojiURL + emojisData[0][1] + "')";
+                document.getElementsByClassName("markItUpButton")[177].style.backgroundSize = "16px 16px";
+                document.getElementsByClassName("markItUpButton")[177].style.backgroundRepeat = "no-repeat";
+                document.getElementsByClassName("markItUpButton")[177].style.zIndex = "300";
+            for (var j = 0, n = emojisData.length; j < n; j++){
+                //Style the dropdown to Scratch's markItUp textbox
+                document.getElementsByClassName("markItUpButton")[j+178].style.backgroundImage = "url('" + emojiURL + emojisData[j][1] + "')";
+                document.getElementsByClassName("markItUpButton")[j+178].style.backgroundSize = "16px 16px";
+                document.getElementsByClassName("markItUpButton")[j+178].style.backgroundRepeat = "no-repeat";
+                document.getElementsByClassName("markItUpButton")[j+178].style.zIndex = "300";
+                
+        }
 };
 
 removeEmojis = function() {


### PR DESCRIPTION
Thought this might convenience users. Some text does go out of the boundry, but we just need to create a list of aliases for them , and use that text (also that could be used for alt text).

# Problem
It seems to think this is a type of scratchblock, so creates the tags. I dunno, I'll fix that later. I just wanted to show you this at an early stage

# This means, do not merge yet, until we work out the scratch-blocks issue